### PR TITLE
fix(base_laser_parameters): Params not set properly since node change

### DIFF
--- a/parameters/hardware/sensors/base_laser_parameters.yaml
+++ b/parameters/hardware/sensors/base_laser_parameters.yaml
@@ -1,4 +1,4 @@
 frame_id: /amigo/base_laser
-min_angle: -2.3
-max_angle: 2.3
+angle_min: -2.0
+angle_max: 2.0
 serial_port: /dev/sensors/hokuyo_busid_3-14


### PR DESCRIPTION
We changed to a different node for our hokuyo laser, but the parameters
weren't updated. Params are named differently in this node.