### PR TITLE
Make action_server not required

### DIFF
--- a/launch/state_machines/free_mode.launch
+++ b/launch/state_machines/free_mode.launch
@@ -22,7 +22,7 @@
     </group>
 
     <!-- Action server state machine -->
-    <node name="state_machine" pkg="action_server" type="main.py" output="log" required="true" >
+    <node name="state_machine" pkg="action_server" type="main.py" output="log" required="false" >
         <param name="robot_name" value="amigo"/>
     </node>
 


### PR DESCRIPTION
Currently the action_server is broken. Revert this change once the rgo2017 branch is merged.